### PR TITLE
Handle existing files in retry

### DIFF
--- a/src/update_agol_vehicles_pallet.py
+++ b/src/update_agol_vehicles_pallet.py
@@ -184,8 +184,8 @@ class AGOLVehiclesPallet(Pallet):
                 description = (f'Vehicle location data obtained from Fleet; updated on {year}-{month}-{day}')
                 feature_item.update(item_properties={'description': description})
 
-            except (HTTPError, URLError) as e:
-                err_msg = (f'Connection error, probably due to connection with AGOL. Attempt {try_count} of 3.')
+            except Exception as e:
+                err_msg = (f'Error on attempt {try_count} of 3; retrying.')
                 self.log.exception(err_msg)
 
                 #: Fail for good if 3x retry fails, otherwise increment, sleep,
@@ -194,8 +194,8 @@ class AGOLVehiclesPallet(Pallet):
                     err_msg = 'Connection errors; giving up after 3 retries'
                     self.log.exception(err_msg)
                     raise e
+                sleep(try_count**2)
                 try_count += 1
-                sleep(10)
                 continue
 
             #: If we haven't gotten an error, break out of while True.

--- a/src/update_agol_vehicles_pallet.py
+++ b/src/update_agol_vehicles_pallet.py
@@ -41,7 +41,7 @@ class AGOLVehiclesPallet(Pallet):
         try:
             latest_csv = csvs[-1]
         except IndexError as e:
-            err_msg = ('Can\'t get last "vehicle_data_*.csv" file- are there any csv files?')
+            err_msg = 'Can\'t get last "vehicle_data_*.csv" file- are there any csv files?'
             self.log.exception(err_msg)
             raise e
 
@@ -58,7 +58,7 @@ class AGOLVehiclesPallet(Pallet):
         today = datetime.date.today()
         previous_dates = [today - datetime.timedelta(days=i) for i in range(previous_days + 1)]
         if previous_days > 0 and csv_datetime not in previous_dates:
-            err_msg = (f'Latest csv "{latest_csv}" not within {previous_days} days of today ({today})')
+            err_msg = f'Latest csv "{latest_csv}" not within {previous_days} days of today ({today})'
             self.log.exception(err_msg)
             raise ValueError(err_msg)
 
@@ -181,11 +181,11 @@ class AGOLVehiclesPallet(Pallet):
                 year = source_date[:4]
                 month = source_date[4:6]
                 day = source_date[6:]
-                description = (f'Vehicle location data obtained from Fleet; updated on {year}-{month}-{day}')
+                description = f'Vehicle location data obtained from Fleet; updated on {year}-{month}-{day}'
                 feature_item.update(item_properties={'description': description})
 
             except Exception as e:
-                err_msg = (f'Error on attempt {try_count} of 3; retrying.')
+                err_msg = f'Error on attempt {try_count} of 3; retrying.'
                 self.log.exception(err_msg)
 
                 #: Fail for good if 3x retry fails, otherwise increment, sleep,

--- a/src/update_agol_vehicles_pallet.py
+++ b/src/update_agol_vehicles_pallet.py
@@ -41,7 +41,7 @@ class AGOLVehiclesPallet(Pallet):
         try:
             latest_csv = csvs[-1]
         except IndexError as e:
-            err_msg = ('Can\'t get last "vehicle_data_*.csv" file- are there ' 'any csv files?')
+            err_msg = ('Can\'t get last "vehicle_data_*.csv" file- are there any csv files?')
             self.log.exception(err_msg)
             raise e
 
@@ -58,7 +58,7 @@ class AGOLVehiclesPallet(Pallet):
         today = datetime.date.today()
         previous_dates = [today - datetime.timedelta(days=i) for i in range(previous_days + 1)]
         if previous_days > 0 and csv_datetime not in previous_dates:
-            err_msg = (f'Latest csv "{latest_csv}" not within {previous_days}' f' days of today ({today})')
+            err_msg = (f'Latest csv "{latest_csv}" not within {previous_days} days of today ({today})')
             self.log.exception(err_msg)
             raise ValueError(err_msg)
 
@@ -138,10 +138,7 @@ class AGOLVehiclesPallet(Pallet):
         os.mkdir(temp_csv_dir)
 
         if not secrets.KNOWNHOSTS or not os.path.isfile(secrets.KNOWNHOSTS):
-            raise FileNotFoundError(
-                f'known_hosts file {secrets.KNOWNHOSTS} not found. Please '
-                'create with ssh-keyscan.'
-            )
+            raise FileNotFoundError(f'known_hosts file {secrets.KNOWNHOSTS} not found. Please create with ssh-keyscan.')
 
         #: Download all the files in the upload folder on sftp to temp_csv_dir
         self.log.info(f'Downloading all files from {secrets.SFTP_HOST}/upload...')
@@ -184,11 +181,11 @@ class AGOLVehiclesPallet(Pallet):
                 year = source_date[:4]
                 month = source_date[4:6]
                 day = source_date[6:]
-                description = ('Vehicle location data obtained from Fleet; ' f'updated on {year}-{month}-{day}')
+                description = (f'Vehicle location data obtained from Fleet; updated on {year}-{month}-{day}')
                 feature_item.update(item_properties={'description': description})
 
             except (HTTPError, URLError) as e:
-                err_msg = ('Connection error, probably due to connection with ' f'AGOL. Attempt {try_count} of 3.')
+                err_msg = (f'Connection error, probably due to connection with AGOL. Attempt {try_count} of 3.')
                 self.log.exception(err_msg)
 
                 #: Fail for good if 3x retry fails, otherwise increment, sleep,


### PR DESCRIPTION
Quick fix for retry failing due to .sd and .sddraft files from first attempt still hanging around in the scratch folder (along with fixes from auto-formatting at new line width).