### PR TITLE
Replace error with warning

### DIFF
--- a/src/update_agol_vehicles_pallet.py
+++ b/src/update_agol_vehicles_pallet.py
@@ -149,7 +149,15 @@ class AGOLVehiclesPallet(Pallet):
             sftp.get_d('upload', temp_csv_dir, preserve_mtime=True)
 
         #: Get the latest file
-        source_path, source_date = self.get_latest_csv(temp_csv_dir, previous_days=7)
+        source_path = None
+        source_date = None
+
+        try:
+            source_path, source_date = self.get_latest_csv(temp_csv_dir, previous_days=7)
+        except Exception as exception:
+            self.status = (False, exception)
+
+            return
 
         self.log.info(f'Converting {source_path} to feature class {temp_fc_path}...')
         wgs84 = arcpy.SpatialReference(4326)


### PR DESCRIPTION
I thought this would be a quick fix as I don't love that it makes forklift look like something broke. This is untested since I do not have a forklift environment and likely wrong. Setting the pallet to false with the message is going to give the same result isn't it? 

I wonder if there needs to be a fake crate with `self.WARNING` added to it rather than setting the pallet status to false or we override get_report and set the result?

@stdavis or @jacobdadams what do you think the correct solution is?

closes #4